### PR TITLE
Use only stable rust

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -38,18 +38,18 @@ impl Error for RwtError {
 
 impl From<Base64Error> for RwtError {
     fn from(error: Base64Error) -> Self {
-        RwtError::Base64(box error)
+        RwtError::Base64(Box::new(error))
     }
 }
 
 impl From<EncodingError> for RwtError {
     fn from(error: EncodingError) -> Self {
-        RwtError::Encoding(box error)
+        RwtError::Encoding(Box::new(error))
     }
 }
 
 impl From<JsonError> for RwtError {
     fn from(error: JsonError) -> Self {
-        RwtError::Json(box error)
+        RwtError::Json(Box::new(error))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax, question_mark)]
-
 extern crate crypto;
 extern crate rustc_serialize;
 extern crate serde;


### PR DESCRIPTION
`rustc` now supports the `?` operator out of the box, which means that we can have a library that works on stable rust if we just dump the `box` syntax we were using for the error types. I don't have a problem with that.